### PR TITLE
Replace linear animation function on chevron.

### DIFF
--- a/styles/fancy-forms/_select-boxes.scss
+++ b/styles/fancy-forms/_select-boxes.scss
@@ -85,6 +85,7 @@
     &:not(:disabled):hover ~ .chevron {
       border-color: $ff-color-selectbox-hover;
       animation: animate-chevron 0.5s forwards;
+      animation-timing-function: ease-in-out;
     }
     
     &.correct:not(:disabled):hover {

--- a/styles/fancy-forms/_select-boxes.scss
+++ b/styles/fancy-forms/_select-boxes.scss
@@ -85,7 +85,7 @@
     &:not(:disabled):hover ~ .chevron {
       border-color: $ff-color-selectbox-hover;
       animation: animate-chevron 0.5s forwards;
-      animation-timing-function: ease-in-out;
+      animation-timing-function: cubic-bezier(0, .69, .67, 1.5);
     }
     
     &.correct:not(:disabled):hover {


### PR DESCRIPTION
Linear animations look a bit jerky on elements that need to reverse direction.
I've changed the chevron animation timing function to a 'playful' example from the css animation book.